### PR TITLE
Telegram Update from October 8, 2015, Chat ID can be a channel username

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -983,9 +983,9 @@ function resolveFile(file) {
 
 function resolveChat(chat) {
   if (chat instanceof Chat) chat = chat.id;
-  if (!utils.isInt(chat))
-    throw new Error("Invalid chat ID");
-  return chat;
+  if (utils.isInt(chat) || utils.isChannel(chat))
+    return chat;
+  throw new Error("Invalid chat ID");
 }
 
 function resolveMessage(msg) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,6 +31,10 @@ checkers.Int = function (x) {
   return typeof x === "number" && x === Math.floor(x);
 };
 
+checkers.Channel = function (x) {
+  return typeof x === "string" && x.indexOf('@') > -1;
+};
+
 checkers.Num = function (x) {
   return typeof x === "number";
 };


### PR DESCRIPTION
Since the [update from October 8, 2015](https://core.telegram.org/bots/api-changelog#october-8-2015) the chat id can be a channel username. Therefore the `resolveChat` function needed a update and a new check needed to be implemented to support the channel username as a chat id. It isn't a neat solution, but it works.... for me 😆 